### PR TITLE
QGIS didn't work in specific versions fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "pathMappings": [
                 {
                     "localRoot": "${workspaceFolder}/src",
-                    "remoteRoot": "C:/Users/${env:USERNAME}/AppData/Roaming/QGIS/QGIS3/profiles/default/python/plugins/QGISPlugin"
+                    "remoteRoot": "C:/Users/${env:USERNAME}/AppData/Roaming/QGIS/QGIS3/profiles/default/python/plugins/AzureMapsCreator"
                 }
             ],
             "justMyCode": false,

--- a/docs/developer-docs/deployment.md
+++ b/docs/developer-docs/deployment.md
@@ -2,6 +2,13 @@
 
 [QGIS Docs to publish plugin](https://plugins.qgis.org/publish/)
 
+## Creating deployment package
+1. Delete the previously compiled package plugin. Typically, it would be located at `QGIS_PLUGIN_DIR = C:\Users\<username>\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins``, under the folder AzureMapsCreator.
+1. Run compile command to generate the plugin package. Check [Readme.md](../../README.md) for more information.
+1. Open the newly compiled plugin directory and make sure there are no log folders.
+1. Zip the file (not the contents of the file). The zip file structure should be: AzureMapsCreator.zip > AzureMapsCreator > <azure-maps-creator-plugin-content>.
+1. Upload the zip in the upcoming processes. 
+
 ## Upload new plugin
 
 1. Get an OSGEO ID from [here](https://www.osgeo.org/community/getting-started-osgeo/osgeo_userid/). This ID is needed to upload a new plugin/make changes to existing one. This is essentially how you login to QGIS Plugin Repository
@@ -12,4 +19,6 @@
 ## Update existing plugin
 1. To update an existing plugin, navigate to [My Plugins][https://plugins.qgis.org/plugins/my]. Select the plugin to update.
 2. You can update an existing version by navigating to versions, and selecting the edit/delete button alongside the version. Date of update doesn't change, fyi.
-1. You can add a new version by navigating to manage tab. Make sure to make changes to the changelog to let users know what was changed.
+1. You can add a new version by navigating to manage tab. 
+    - Make sure to make changes to the changelog to let users know what was changed. Also write the changes in the QGIS plugin repository changelog, which is available when uploading the new version.
+    - Make sure to bump up version in [metada.txt](../../src/metadata.txt)

--- a/src/helpers/AzureMapsPluginRequestHandler.py
+++ b/src/helpers/AzureMapsPluginRequestHandler.py
@@ -125,6 +125,8 @@ class AzureMapsPluginRequestHandler:
         headers = {"content-type": content_type} if content_type else {} # Set the headers
         headers['User-Agent'] = Constants.AzureMapsQGISPlugin.USER_AGENT # Add the user agent to the headers
         headers['QGIS-Version'] = Qgis.QGIS_VERSION
+        for key,value in headers.items():
+            headers[key] = value.encode('latin-1','ignore').decode('latin-1') # Encode the headers
 
         verify_ssl = False if self.geography == Constants.Geography.LOCALHOST else True
 

--- a/src/metadata.txt
+++ b/src/metadata.txt
@@ -2,7 +2,7 @@
 name=Azure Maps Creator
 qgisMinimumVersion=3.22
 description=Provides access to Azure Maps Creator services
-version=1.0.0
+version=1.0.1
 author=Azure Maps Creator
 email=am-creator-qgis@microsoft.com
 


### PR DESCRIPTION
What
> QGIS didn't work in specific versions. Sent out a fix. Released a new version and updated deployment docs to add more instructions on how to deploy.

Why
> The headers contained invalid characters, which threw an error.

How
> Encoded and decoded the headers to make characters valid.